### PR TITLE
Add namespace to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,8 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 31
 
+    namespace = "com.cleveroad.cr_file_saver"
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
After upgrading Android Gradle Plugin to avoid imperative mode following https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply, the cr_file_saver fails to build without a namespace.

A problem occurred configuring project ':cr_file_saver'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Please specify a namespace in the module's build.gradle file like so:
     android {
         namespace 'com.example.namespace'
     }

This adds a namespace to fix the issue